### PR TITLE
AA-51-create-maintenance-records-CRUD-endpoints

### DIFF
--- a/migrations/20231208020549-update-appointments-table.js
+++ b/migrations/20231208020549-update-appointments-table.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.dropColumn('Services', 'serviceRequest', {
+      type: Sequelize.ARRAY(Sequelize.STRING),
+      allowNull: false
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Services', 'serviceRequest', {
+      type: Sequelize.ARRAY(Sequelize.STRING),
+      allowNull: false
+    });
+  }
+};

--- a/migrations/20231208020549-update-appointments-table.js
+++ b/migrations/20231208020549-update-appointments-table.js
@@ -3,14 +3,14 @@
 /** @type {import('sequelize-cli').Migration} */
 module.exports = {
   async up(queryInterface, Sequelize) {
-    await queryInterface.dropColumn('Services', 'serviceRequest', {
+    await queryInterface.removeColumn('Appointments', 'serviceRequest', {
       type: Sequelize.ARRAY(Sequelize.STRING),
       allowNull: false
     });
   },
 
   async down(queryInterface, Sequelize) {
-    await queryInterface.addColumn('Services', 'serviceRequest', {
+    await queryInterface.addColumn('Appointments', 'serviceRequest', {
       type: Sequelize.ARRAY(Sequelize.STRING),
       allowNull: false
     });

--- a/migrations/20231208082149-update-maintenance-record-table.js
+++ b/migrations/20231208082149-update-maintenance-record-table.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('MaintenanceRecords', 'vehicleId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'Vehicles',
+        key: 'id'
+      }
+    });
+
+    await queryInterface.addColumn('MaintenanceRecords', 'appointmentId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'Appointments',
+        key: 'id'
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('MaintenanceRecords', 'vehicleId');
+    await queryInterface.removeColumn('MaintenanceRecords', 'appointmentId');
+  }
+};

--- a/migrations/20231208090337-remove-appointmentId-from-mtce-records-table.js
+++ b/migrations/20231208090337-remove-appointmentId-from-mtce-records-table.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('MaintenanceRecords', 'appointmentId');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.addColumn('MaintenanceRecords', 'appointmentId', {
+      type: Sequelize.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Appointments',
+        key: 'id'
+      }
+    });
+  }
+};

--- a/migrations/20231208090653-add-maintenancerecordsid-to-appointments-table.js
+++ b/migrations/20231208090653-add-maintenancerecordsid-to-appointments-table.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Appointments', 'maintenanceRecordId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'MaintenanceRecords',
+        key: 'id'
+      }
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Appointments', 'maintenanceRecordId');
+  }
+};

--- a/migrations/20231208114915-add-appointmentId-to-mtce-records-table.js
+++ b/migrations/20231208114915-add-appointmentId-to-mtce-records-table.js
@@ -1,0 +1,30 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('MaintenanceRecords', 'appointmentId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'Appointments',
+        key: 'id'
+      }
+    });
+
+    await queryInterface.removeColumn('Appointments', 'maintenanceRecordId');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('MaintenanceRecords', 'appointmentId');
+
+    await queryInterface.addColumn('Appointments', 'maintenanceRecordId', {
+      type: Sequelize.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'MaintenanceRecords',
+        key: 'id'
+      }
+    });
+  }
+};

--- a/migrations/20231210023608-add-serviceId-and-inventoryId-to-mtce-records-table.js
+++ b/migrations/20231210023608-add-serviceId-and-inventoryId-to-mtce-records-table.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('MaintenanceRecords', 'serviceId', {
+      type: Sequelize.ARRAY(Sequelize.INTEGER),
+      allowNull: true
+    });
+
+    await queryInterface.addColumn('MaintenanceRecords', 'inventoryId', {
+      type: Sequelize.ARRAY(Sequelize.INTEGER),
+      allowNull: true
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('MaintenanceRecords', 'serviceId');
+    await queryInterface.removeColumn('MaintenanceRecords', 'inventoryId');
+  }
+};

--- a/migrations/20231210024305-add-serviceId-to-appointments-table.js
+++ b/migrations/20231210024305-add-serviceId-to-appointments-table.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('Appointments', 'serviceId', {
+      type: Sequelize.ARRAY(Sequelize.INTEGER),
+      allowNull: true
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.removeColumn('Appointments', 'serviceId');
+  }
+};

--- a/src/app.js
+++ b/src/app.js
@@ -16,6 +16,7 @@ const { morganMiddleware } = require('./config/logging');
 const unknownEndpoint = require('./middlewares/unknownEndpoint');
 const morgan = require('morgan');
 const swaggerDocs = require('./swagger-ui/swagger');
+const maintenanceRecordsRouter = require('./routes/maintenancerecordRoutes');
 
 // middlewares
 app.use(bodyParser.json());
@@ -33,6 +34,7 @@ app.use('/api/vehicles', vehiclesRouter);
 app.use('/api/appointments', appointmentsRouter);
 app.use('/api/inventory', inventoryRouter);
 app.use('/api/services', servicesRouter);
+app.use('/api/maintenance-records', maintenanceRecordsRouter);
 
 // middleware for testing purposes
 if (process.env.NODE_ENV === 'test') {

--- a/src/controller/appointment.js
+++ b/src/controller/appointment.js
@@ -91,8 +91,7 @@ const updateAppointment = async (req, res) => {
 const createServiceRequest = async (req, res) => {
   const { appointmentId } = req.validatedPartialAppointment;
   const user = req.user;
-
-  console.log('request body', req.body);
+  const appointmentStatus = 'approved';
 
   // check if appointment exists
   const appointment = await Appointment.findByPk(appointmentId, {
@@ -103,14 +102,12 @@ const createServiceRequest = async (req, res) => {
     ]
   });
 
-  console.log('appointmentId', appointment, req.validatedPartialAppointment);
-
   // create service request if appointment does not exist
   if (!appointment) {
     // create appointment
     const newAppointment = await Appointment.create({
       ...req.validatedPartialAppointment,
-      status: 'approved',
+      status: appointmentStatus,
       date: new Date(),
       updatedBy: user.id
     });
@@ -132,7 +129,7 @@ const createServiceRequest = async (req, res) => {
   // create service request with existing appointment
   const newAppointment = await appointment.update({
     ...appointment,
-    status: 'approved',
+    status: appointmentStatus,
     updatedBy: user.id
   });
 

--- a/src/controller/helpers/attachInventory.js
+++ b/src/controller/helpers/attachInventory.js
@@ -1,0 +1,18 @@
+const Inventory = require('../../models/inventory');
+
+const attachInventory = async (hostModel, inventoryId) => {
+  // check if services in serviceId array exist
+  const inventories = await Inventory.findAll({
+    where: { id: inventoryId }
+  });
+
+  // check that the services returned are the same as the ones in the serviceId array
+  if (inventories.length !== inventoryId.length) {
+    return res.status(404).json({ error: 'Inventory not found' });
+  }
+
+  // add selected services in serviceId array to the hostModel
+  await hostModel.addInventories(inventories);
+};
+
+module.exports = attachInventory;

--- a/src/controller/helpers/attachInventory.js
+++ b/src/controller/helpers/attachInventory.js
@@ -1,6 +1,6 @@
 const Inventory = require('../../models/inventory');
 
-const attachInventory = async (hostModel, inventoryId) => {
+const attachInventory = async (hostModel, inventoryId, res) => {
   // check if services in serviceId array exist
   const inventories = await Inventory.findAll({
     where: { id: inventoryId }

--- a/src/controller/helpers/attachServices.js
+++ b/src/controller/helpers/attachServices.js
@@ -1,0 +1,18 @@
+const Service = require('../../models/service');
+
+const attachServices = async (hostModel, serviceId) => {
+  // check if services in serviceId array exist
+  const services = await Service.findAll({
+    where: { id: serviceId }
+  });
+
+  // check that the services returned are the same as the ones in the serviceId array
+  if (services.length !== serviceId.length) {
+    return res.status(404).json({ error: 'Service not found' });
+  }
+
+  // add selected services in serviceId array to the hostModel
+  await hostModel.addServices(services);
+};
+
+module.exports = attachServices;

--- a/src/controller/helpers/attachServices.js
+++ b/src/controller/helpers/attachServices.js
@@ -1,6 +1,6 @@
 const Service = require('../../models/service');
 
-const attachServices = async (hostModel, serviceId) => {
+const attachServices = async (hostModel, serviceId, res) => {
   // check if services in serviceId array exist
   const services = await Service.findAll({
     where: { id: serviceId }

--- a/src/controller/inventory.js
+++ b/src/controller/inventory.js
@@ -12,7 +12,7 @@ const getInventoryById = async (req, res) => {
   const { inventoryId } = req.validatedInventoryId;
 
   // check user role
-  checkUserRole(user);
+  checkUserRole(['admin', 'superAdmin'], user, res);
 
   // check if inventory exists
   const inventory = await Inventory.findByPk(inventoryId);
@@ -30,7 +30,7 @@ const getInventoryAndUser = async (req, res) => {
   const { inventoryId } = req.validatedInventoryId;
 
   // check user role
-  checkUserRole(user, res);
+  checkUserRole(['admin', 'superAdmin'], user, res);
 
   // check if inventory exists
   const inventory = await Inventory.findByPk(inventoryId);
@@ -51,7 +51,7 @@ const updateInventory = async (req, res) => {
   const user = req.user;
 
   // check user role
-  checkUserRole(user, res);
+  checkUserRole(['admin', 'superAdmin'], user, res);
 
   // check if inventory exists
   const inventory = await Inventory.findByPk(inventoryId);
@@ -89,7 +89,7 @@ const deleteInventory = async (req, res) => {
   const { inventoryId } = req.validatedInventoryId;
 
   // check user role
-  checkUserRole(user, res);
+  checkUserRole(['admin', 'superAdmin'], user, res);
 
   // check if inventory exists
   const inventory = await Inventory.findByPk(inventoryId);

--- a/src/controller/maintenanceRecord.js
+++ b/src/controller/maintenanceRecord.js
@@ -5,6 +5,7 @@ const Inventory = require('../models/inventory');
 const User = require('../models/user');
 const Service = require('../models/service');
 const { checkUserRole } = require('../middlewares/authMiddleware');
+const attachServices = require('./helpers/attachServices');
 
 // Get all maintenance records
 const getMaintenanceRecords = async (req, res) => {
@@ -56,7 +57,11 @@ const getMaintenanceRecordAndUser = async (req, res) => {
 // Update a maintenance record by ID
 const updateMaintenanceRecord = async (req, res) => {
   const { maintenanceRecordId } = req.validatedMaintenanceRecordId;
-  const { status } = req.validatedPartialMaintenanceRecord;
+  const {
+    status: appointmentStatus,
+    serviceId,
+    inventoryId
+  } = req.validatedPartialMaintenanceRecord;
   const user = req.user;
 
   // check user role
@@ -71,9 +76,37 @@ const updateMaintenanceRecord = async (req, res) => {
     return;
   }
 
+  // check if appointment exists
+  const appointment = await Appointment.findByPk(
+    maintenanceRecord.appointmentId
+  );
+
+  if (!appointment) {
+    res.status(404).json({ error: 'Appointment not found' });
+    return;
+  }
+
+  // if status is completed, update the appointment status to completed
+  if (appointmentStatus === 'completed') {
+    // Update the appointment
+    const [updatedRows] = await Appointment.update(
+      { status: appointmentStatus, updatedBy: user.id },
+      {
+        where: { id: appointment.id }
+      }
+    );
+
+    if (updatedRows === 0) {
+      res.status(404).json({ error: 'Appointment not found' });
+      return;
+    }
+  }
+
+  // Update the maintenance record
   const [updatedRows] = await MaintenanceRecord.update(
     {
-      ...req.validatedPartialMaintenanceRecord
+      ...req.validatedPartialMaintenanceRecord,
+      updatedBy: user.id
     },
     {
       where: { id: maintenanceRecordId }
@@ -88,6 +121,16 @@ const updateMaintenanceRecord = async (req, res) => {
   // Get the updated maintenance record record
   const updatedMaintenanceRecord =
     await MaintenanceRecord.findByPk(maintenanceRecordId);
+
+  // if serviceId is provided, attach services to appointment
+  if (serviceId) {
+    attachServices(updatedMaintenanceRecord, serviceId);
+  }
+
+  // if inventoryId is provided, attach inventory to appointment
+  if (inventoryId) {
+    attachInventory(updatedMaintenanceRecord, inventoryId);
+  }
 
   res.status(200).json({
     maintenanceRecord: updatedMaintenanceRecord,

--- a/src/controller/maintenanceRecord.js
+++ b/src/controller/maintenanceRecord.js
@@ -1,0 +1,106 @@
+const MaintenanceRecord = require('../models/maintenanceRecord');
+const Appointment = require('../models/appointment');
+const Vehicle = require('../models/vehicle');
+const Inventory = require('../models/inventory');
+const User = require('../models/user');
+const Service = require('../models/service');
+
+// Get all maintenance records
+const getMaintenanceRecords = async (req, res) => {
+  const maintenanceRecords = await MaintenanceRecord.findAll();
+  res.status(200).json(maintenanceRecords);
+};
+
+// Get a specific maintenance record by ID
+const getMaintenanceRecordById = async (req, res) => {
+  const { maintenanceRecordId } = req.validatedMaintenanceRecordId;
+
+  // check user role
+  checkUserRole(user);
+
+  // check if maintenance record exists
+  const maintenanceRecord =
+    await MaintenanceRecord.findByPk(maintenanceRecordId);
+
+  if (!maintenanceRecord) {
+    res.status(404).json({ error: 'Maintenance record not found' });
+    return;
+  }
+
+  res.status(200).json(maintenanceRecord);
+};
+
+// Get a maintenance record and the user associated with it
+const getMaintenanceRecordAndUser = async (req, res) => {
+  const { maintenanceRecordId } = req.validatedMaintenanceRecordId;
+
+  // check user role
+  checkUserRole(user, res);
+
+  // check if maintenance record exists
+  const maintenanceRecord =
+    await MaintenanceRecord.findByPk(maintenanceRecordId);
+
+  if (!maintenanceRecord) {
+    res.status(404).json({ error: 'Maintenance record not found' });
+    return;
+  }
+
+  const user = await maintenanceRecord.getUser();
+
+  res.status(200).json({ maintenanceRecord, user });
+};
+
+// Update a maintenance record by ID
+const updateMaintenanceRecord = async (req, res) => {
+  const { maintenanceRecordId } = req.validatedMaintenanceRecordId;
+  const user = req.user;
+
+  // check user role
+  checkUserRole(['admin', 'superAdmin'], user, res);
+
+  // check if maintenance record exists
+  const maintenanceRecord =
+    await MaintenanceRecord.findByPk(maintenanceRecordId);
+
+  if (!maintenanceRecord) {
+    res.status(404).json({ error: 'Maintenance record not found' });
+    return;
+  }
+
+  // Update the maintenance record
+  await maintenanceRecord.update(req.validatedData);
+
+  res.status(200).json(maintenanceRecord);
+};
+
+// Delete a maintenance record by ID
+const deleteMaintenanceRecord = async (req, res) => {
+  const { maintenanceRecordId } = req.validatedMaintenanceRecordId;
+  const user = req.user;
+
+  // check user role
+  checkUserRole(user, res);
+
+  // check if maintenance record exists
+  const maintenanceRecord =
+    await MaintenanceRecord.findByPk(maintenanceRecordId);
+
+  if (!maintenanceRecord) {
+    res.status(404).json({ error: 'Maintenance record not found' });
+    return;
+  }
+
+  // Delete the maintenance record
+  await maintenanceRecord.destroy();
+
+  res.status(204).end();
+};
+
+module.exports = {
+  getMaintenanceRecords,
+  getMaintenanceRecordById,
+  getMaintenanceRecordAndUser,
+  updateMaintenanceRecord,
+  deleteMaintenanceRecord
+};

--- a/src/controller/service.js
+++ b/src/controller/service.js
@@ -47,7 +47,7 @@ const updateService = async (req, res) => {
   console.log('user', user, 'serviceId', serviceId);
 
   // check user role
-  checkUserRole(user, res);
+  checkUserRole(['admin', 'superAdmin'], user, res);
 
   // check if service exists
   const service = await Service.findByPk(serviceId);
@@ -87,7 +87,7 @@ const deleteService = async (req, res) => {
   const user = req.user;
 
   // check user role
-  checkUserRole(user, res);
+  checkUserRole(['admin', 'superAdmin'], user, res);
 
   // check if service exists
   const service = await Service.findByPk(serviceId);

--- a/src/controller/user.js
+++ b/src/controller/user.js
@@ -76,9 +76,23 @@ const createAppointment = async (req, res) => {
     return res.status(404).json({ error: 'Vehicle not found' });
   }
 
+  // check if all service exists
+  const service = await Service.findByAll({
+    where: { id: serviceId }
+  });
+
+  if (!service[0]) {
+    return res.status(404).json({ error: 'Service not found' });
+  }
+
   // check if appointment exists
   const existingAppointment = await Appointment.findOne({
-    where: { date: date, vehicleId: vehicleId, userId: user.id }
+    where: {
+      date: date,
+      vehicleId: vehicleId,
+      serviceId: serviceId,
+      userId: user.id
+    }
   });
 
   if (existingAppointment) {

--- a/src/controller/user.js
+++ b/src/controller/user.js
@@ -5,6 +5,7 @@ const Appointment = require('../models/appointment');
 const Inventory = require('../models/inventory');
 const Service = require('../models/service');
 const { checkUserRole } = require('../middlewares/authMiddleware');
+const attachServices = require('./helpers/attachServices');
 
 // Create a new user
 const createUser = async (req, res) => {
@@ -57,7 +58,7 @@ const addUserVehicle = async (req, res) => {
 
 // Create a new appointment
 const createAppointment = async (req, res) => {
-  const { date, vehicleId } = req.validatedData;
+  const { date, vehicleId, serviceId } = req.validatedData;
   const user = req.user;
 
   if (!user) {
@@ -89,8 +90,6 @@ const createAppointment = async (req, res) => {
     where: { date: date, vehicleId: vehicleId, userId: user.id }
   });
 
-  console.log('existing', appointments);
-
   if (appointments.length >= 3) {
     return res
       .status(409)
@@ -103,6 +102,9 @@ const createAppointment = async (req, res) => {
     userId: user.id,
     vehicleId: vehicleId
   });
+
+  // attach services to appointment
+  attachServices(appointment, serviceId);
 
   res.status(201).json({ appointment, vehicle, user });
 };

--- a/src/middlewares/authMiddleware.js
+++ b/src/middlewares/authMiddleware.js
@@ -56,11 +56,11 @@ const isValidPassword = (password) => {
 };
 
 // check if user has admin or superAdmin role
-const checkUserRole = (existingUser, res) => {
-  if (existingUser.roles === 'user') {
+const checkUserRole = (requiredRoles, existingUser, res) => {
+  if (!requiredRoles.includes(existingUser.roles)) {
     return res
       .status(401)
-      .json({ error: 'You are not authorized to create an inventory' });
+      .json({ error: 'You are not authorized to carry out this activity' });
   }
 
   return true;

--- a/src/middlewares/validations/validateAppointments.js
+++ b/src/middlewares/validations/validateAppointments.js
@@ -3,7 +3,8 @@ const joi = require('joi');
 const validateAppointmentsSchema = joi.object({
   date: joi.date().required(),
   note: joi.string().required(),
-  vehicleId: joi.number().required()
+  vehicleId: joi.number().required(),
+  serviceId: joi.array().items(joi.number()).required()
 });
 
 const validateAppointmentsIdSchema = joi.object({
@@ -17,6 +18,7 @@ const validatePartialAppointmentSchema = joi.object({
   vehicleId: joi.number(),
   status: joi.string(),
   updatedBy: joi.number(),
+  serviceId: joi.array().items(joi.number()),
   deletedAt: joi.date()
 });
 

--- a/src/middlewares/validations/validateAppointments.js
+++ b/src/middlewares/validations/validateAppointments.js
@@ -3,8 +3,7 @@ const joi = require('joi');
 const validateAppointmentsSchema = joi.object({
   date: joi.date().required(),
   note: joi.string().required(),
-  vehicleId: joi.number().required(),
-  serviceRequest: joi.array().required()
+  vehicleId: joi.number().required()
 });
 
 const validateAppointmentsIdSchema = joi.object({
@@ -15,7 +14,6 @@ const validatePartialAppointmentSchema = joi.object({
   date: joi.date(),
   note: joi.string(),
   vehicleId: joi.number(),
-  serviceRequest: joi.array(),
   status: joi.string(),
   updatedBy: joi.number(),
   deletedAt: joi.date()

--- a/src/middlewares/validations/validateAppointments.js
+++ b/src/middlewares/validations/validateAppointments.js
@@ -11,6 +11,7 @@ const validateAppointmentsIdSchema = joi.object({
 });
 
 const validatePartialAppointmentSchema = joi.object({
+  appointmentId: joi.number(),
   date: joi.date(),
   note: joi.string(),
   vehicleId: joi.number(),

--- a/src/middlewares/validations/validateMaintenanceRecord.js
+++ b/src/middlewares/validations/validateMaintenanceRecord.js
@@ -1,0 +1,45 @@
+const joi = require('joi');
+
+const validateMaintenanceRecordIdSchema = joi.object({
+  maintenanceRecordId: joi.number().required()
+});
+
+const validatePartialMaintenanceRecordSchema = joi.object({
+  maintenanceRecordId: joi.number(),
+  date: joi.date(),
+  status: joi.string(),
+  description: joi.string(),
+  updatedBy: joi.number(),
+  deletedAt: joi.date()
+});
+
+const validateMaintenanceRecordsId = (req, res, next) => {
+  const { error, value } = validateMaintenanceRecordIdSchema.validate(
+    req.params
+  );
+
+  if (error) {
+    return res.status(400).json({ error: error.details[0].message });
+  }
+
+  req.validatedMaintenanceRecordId = value;
+  next();
+};
+
+const validatePartialMaintenanceRecord = (req, res, next) => {
+  const { error, value } = validatePartialMaintenanceRecordSchema.validate(
+    req.body
+  );
+
+  if (error) {
+    return res.status(400).json({ error: error.details[0].message });
+  }
+
+  req.validatedPartialMaintenanceRecord = value;
+  next();
+};
+
+module.exports = {
+  validateMaintenanceRecordsId,
+  validatePartialMaintenanceRecord
+};

--- a/src/middlewares/validations/validateMaintenanceRecord.js
+++ b/src/middlewares/validations/validateMaintenanceRecord.js
@@ -10,7 +10,9 @@ const validatePartialMaintenanceRecordSchema = joi.object({
   status: joi.string(),
   description: joi.string(),
   updatedBy: joi.number(),
-  deletedAt: joi.date()
+  deletedAt: joi.date(),
+  serviceId: joi.array().items(joi.number()),
+  inventoryId: joi.array().items(joi.number())
 });
 
 const validateMaintenanceRecordsId = (req, res, next) => {

--- a/src/models/appointment.js
+++ b/src/models/appointment.js
@@ -11,13 +11,9 @@ const Appointment = sequelize.define(
       type: DataTypes.DATE,
       allowNull: false
     },
-    serviceRequest: {
-      type: DataTypes.ARRAY(DataTypes.STRING),
-      allowNull: false
-    },
     note: {
       type: DataTypes.STRING,
-      allowNull: false
+      allowNull: true
     },
     status: {
       type: DataTypes.STRING,

--- a/src/models/appointment.js
+++ b/src/models/appointment.js
@@ -21,6 +21,10 @@ const Appointment = sequelize.define(
       defaultValue: 'pending',
       values: ['pending', 'approved', 'rejected', 'completed']
     },
+    serviceId: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
+      allowNull: true
+    },
     updatedBy: {
       type: DataTypes.INTEGER,
       allowNull: true

--- a/src/models/appointment.js
+++ b/src/models/appointment.js
@@ -2,6 +2,7 @@ const { DataTypes } = require('sequelize');
 const sequelize = require('../config/database');
 const User = require('./user');
 const Vehicle = require('./vehicle');
+const Service = require('./service');
 
 const Appointment = sequelize.define(
   'Appointment',
@@ -48,5 +49,9 @@ Appointment.belongsTo(User, { foreignKey: 'userId' });
 // Define the one-to-many relationship for Vehicle and Appointment
 Vehicle.hasMany(Appointment, { foreignKey: 'vehicleId' });
 Appointment.belongsTo(Vehicle, { foreignKey: 'vehicleId' });
+
+// Define the one-to-many relationship for Appointment and Service
+Appointment.hasMany(Service, { foreignKey: 'appointmentId' });
+Service.belongsTo(Appointment, { foreignKey: 'appointmentId' });
 
 module.exports = Appointment;

--- a/src/models/appointment.js
+++ b/src/models/appointment.js
@@ -50,8 +50,11 @@ Appointment.belongsTo(User, { foreignKey: 'userId' });
 Vehicle.hasMany(Appointment, { foreignKey: 'vehicleId' });
 Appointment.belongsTo(Vehicle, { foreignKey: 'vehicleId' });
 
-// Define the one-to-many relationship for Appointment and Service
-Appointment.hasMany(Service, { foreignKey: 'appointmentId' });
-Service.belongsTo(Appointment, { foreignKey: 'appointmentId' });
+// Define the many-to-many relationship for Appointment and Service
+Appointment.belongsToMany(Service, {
+  through: 'AppointmentService',
+  foreignKey: 'appointmentId',
+  otherKey: 'serviceId'
+});
 
 module.exports = Appointment;

--- a/src/models/maintenanceRecord.js
+++ b/src/models/maintenanceRecord.js
@@ -23,6 +23,22 @@ const MaintenanceRecord = sequelize.define(
       type: DataTypes.TEXT,
       allowNull: true
     },
+    appointmentId: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
+    vehicleId: {
+      type: DataTypes.INTEGER,
+      allowNull: false
+    },
+    serviceId: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
+      allowNull: true
+    },
+    inventoryId: {
+      type: DataTypes.ARRAY(DataTypes.INTEGER),
+      allowNull: true
+    },
     duration: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/src/models/maintenanceRecord.js
+++ b/src/models/maintenanceRecord.js
@@ -1,0 +1,118 @@
+const { DataTypes } = require('sequelize');
+const sequelize = require('../config/database');
+const User = require('./user');
+const Service = require('./service');
+const Inventory = require('./inventory');
+const Appointment = require('./appointment');
+
+const MaintenanceRecord = sequelize.define(
+  'MaintenanceRecord',
+  {
+    vehicleId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Vehicles',
+        key: 'id'
+      }
+    },
+    appointmentId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Appointments',
+        key: 'id'
+      }
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'Users',
+        key: 'id'
+      }
+    },
+    startDate: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    endDate: {
+      type: DataTypes.DATE,
+      allowNull: true
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true
+    },
+    duration: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 0
+    },
+    updatedBy: {
+      type: DataTypes.INTEGER,
+      allowNull: true
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  },
+  {
+    // Exclude deletedAt field by default when converting to JSON
+    defaultScope: {
+      attributes: { exclude: ['deletedAt'] }
+    },
+    hooks: {
+      beforeSave: (maintenanceRecord, options) => {
+        return new Promise((resolve) => {
+          // Calculate the finalPrice before saving
+          if (maintenanceRecord.endDate === null) {
+            maintenanceRecord.endDate = new Date();
+          }
+
+          const startDate = new Date(maintenanceRecord.startDate);
+          const endDate = new Date(maintenanceRecord.endDate);
+
+          if (startDate - endDate === 0) {
+            maintenanceRecord.duration = 1;
+            resolve();
+          }
+
+          maintenanceRecord.duration = startDate - endDate;
+          resolve();
+        });
+      }
+    }
+  }
+);
+
+// Define the relationship between MaintenanceRecords and User
+User.hasMany(MaintenanceRecord, { foreignKey: 'userId' });
+MaintenanceRecord.belongsTo(User, { foreignKey: 'userId' });
+
+// Define the many-to-many relationship between MaintenanceRecords and Service
+MaintenanceRecord.belongsToMany(Service, {
+  through: 'MaintenanceRecordService',
+  foreignKey: 'maintenanceRecordId',
+  otherKey: 'serviceId'
+});
+
+// Define the many-to-many relationship between MaintenanceRecords and Inventory
+MaintenanceRecord.belongsToMany(Inventory, {
+  through: 'MaintenanceRecordInventory',
+  foreignKey: 'maintenanceRecordId',
+  otherKey: 'inventoryId'
+});
+
+// Define a one-to-one relationship between MaintenanceRecords and Appointment
+MaintenanceRecord.hasOne(Appointment, { foreignKey: 'appointmentId' });
+Appointment.belongsTo(MaintenanceRecord, {
+  foreignKey: 'appointmentId'
+});
+
+// Define the one-to-many relationship between MaintenanceRecords and Vehicle
+MaintenanceRecord.belongsTo(Vehicle, { foreignKey: 'vehicleId' });
+Vehicle.hasMany(MaintenanceRecord, { foreignKey: 'vehicleId' });
+
+module.export = MaintenanceRecord;

--- a/src/models/maintenanceRecord.js
+++ b/src/models/maintenanceRecord.js
@@ -8,37 +8,14 @@ const Appointment = require('./appointment');
 const MaintenanceRecord = sequelize.define(
   'MaintenanceRecord',
   {
-    vehicleId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'Vehicles',
-        key: 'id'
-      }
-    },
-    appointmentId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'Appointments',
-        key: 'id'
-      }
-    },
-    userId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      references: {
-        model: 'Users',
-        key: 'id'
-      }
-    },
     startDate: {
       type: DataTypes.DATE,
       allowNull: false
     },
     endDate: {
       type: DataTypes.DATE,
-      allowNull: true
+      allowNull: true,
+      defaultValue: null
     },
     description: {
       type: DataTypes.TEXT,

--- a/src/models/maintenanceRecord.js
+++ b/src/models/maintenanceRecord.js
@@ -4,13 +4,15 @@ const User = require('./user');
 const Service = require('./service');
 const Inventory = require('./inventory');
 const Appointment = require('./appointment');
+const Vehicle = require('./vehicle');
 
 const MaintenanceRecord = sequelize.define(
   'MaintenanceRecord',
   {
     startDate: {
       type: DataTypes.DATE,
-      allowNull: false
+      allowNull: false,
+      defaultValue: new Date()
     },
     endDate: {
       type: DataTypes.DATE,
@@ -56,7 +58,13 @@ const MaintenanceRecord = sequelize.define(
             resolve();
           }
 
-          maintenanceRecord.duration = startDate - endDate;
+          // Calculate duration in days
+          const millisecondsInADay = 24 * 60 * 60 * 1000; // 1 day = 24 hours * 60 minutes * 60 seconds * 1000 milliseconds
+          const durationInDays = Math.ceil(
+            (endDate - startDate) / millisecondsInADay
+          );
+
+          maintenanceRecord.duration = durationInDays;
           resolve();
         });
       }
@@ -83,13 +91,13 @@ MaintenanceRecord.belongsToMany(Inventory, {
 });
 
 // Define a one-to-one relationship between MaintenanceRecords and Appointment
-MaintenanceRecord.hasOne(Appointment, { foreignKey: 'appointmentId' });
+MaintenanceRecord.hasOne(Appointment, { foreignKey: 'maintenanceRecordId' });
 Appointment.belongsTo(MaintenanceRecord, {
-  foreignKey: 'appointmentId'
+  foreignKey: 'maintenanceRecordId'
 });
 
 // Define the one-to-many relationship between MaintenanceRecords and Vehicle
 MaintenanceRecord.belongsTo(Vehicle, { foreignKey: 'vehicleId' });
 Vehicle.hasMany(MaintenanceRecord, { foreignKey: 'vehicleId' });
 
-module.export = MaintenanceRecord;
+module.exports = MaintenanceRecord;

--- a/src/models/maintenanceRecord.js
+++ b/src/models/maintenanceRecord.js
@@ -90,12 +90,6 @@ MaintenanceRecord.belongsToMany(Inventory, {
   otherKey: 'inventoryId'
 });
 
-// Define a one-to-one relationship between MaintenanceRecords and Appointment
-MaintenanceRecord.hasOne(Appointment, { foreignKey: 'maintenanceRecordId' });
-Appointment.belongsTo(MaintenanceRecord, {
-  foreignKey: 'maintenanceRecordId'
-});
-
 // Define the one-to-many relationship between MaintenanceRecords and Vehicle
 MaintenanceRecord.belongsTo(Vehicle, { foreignKey: 'vehicleId' });
 Vehicle.hasMany(MaintenanceRecord, { foreignKey: 'vehicleId' });

--- a/src/routes/appointmentRoutes.js
+++ b/src/routes/appointmentRoutes.js
@@ -5,7 +5,6 @@ appointmentsRouter.use(bodyParser.json());
 const authMiddleware = require('../middlewares/authMiddleware');
 const {
   validateAppointmentsId,
-  validateAppointments,
   validatePartialAppointment
 } = require('../middlewares/validations/validateAppointments');
 
@@ -107,12 +106,12 @@ appointmentsRouter.get(
  *              date:
  *                type: string
  *                default: ''
- *              time:
+ *              status:
  *                type: string
- *                default: ''
+ *                default: approved
  *              note:
  *                type: string
- *                default: ''
+ *                default: This is a note
  *     responses:
  *      200:
  *        description: Modified
@@ -129,6 +128,46 @@ appointmentsRouter.put(
   validateAppointmentsId,
   validatePartialAppointment,
   appointmentController.updateAppointment
+);
+
+/** POST Methods */
+/**
+ * @openapi
+ * '/api/appointments/{appointmentId}':
+ *  post:
+ *     tags:
+ *     - Appointment Controller
+ *     summary: Create a Service Request
+ *     requestBody:
+ *      required: true
+ *      content:
+ *        application/json:
+ *           schema:
+ *            type: object
+ *            required:
+ *              - appointmentId
+ *            properties:
+ *              note:
+ *                type: string
+ *                default: This is a note
+ *              serviceId:
+ *                type: [integer]
+ *                default: [1,2]
+ *     responses:
+ *      200:
+ *        description: Modified
+ *      400:
+ *        description: Bad Request
+ *      404:
+ *        description: Not Found
+ *      500:
+ *        description: Server Error
+ */
+appointmentsRouter.post(
+  '/create-service-request',
+  authMiddleware.userExtractor,
+  validatePartialAppointment,
+  appointmentController.createServiceRequest
 );
 
 /** DELETE Methods */

--- a/src/routes/maintenanceRecordRoutes.js
+++ b/src/routes/maintenanceRecordRoutes.js
@@ -1,0 +1,160 @@
+const maintenanceRecordController = require('../controller/maintenanceRecord');
+const bodyParser = require('body-parser');
+const maintenanceRecordsRouter = require('express').Router();
+maintenanceRecordsRouter.use(bodyParser.json());
+const authMiddleware = require('../middlewares/authMiddleware');
+const {
+  validateMaintenanceRecordsId,
+  validatePartialMaintenanceRecord
+} = require('../middlewares/validations/validateMaintenanceRecord');
+
+// maintenanceRecord routes
+/** GET Methods */
+/**
+ * @openapi
+ * '/api/maintenanceRecords':
+ *  get:
+ *    tags:
+ *    - MaintenanceRecord Controller
+ *    summary: Get all maintenanceRecords
+ *    responses:
+ *     200:
+ *       description: Fetched Successfully
+ *     400:
+ *       description: Bad Request
+ *     404:
+ *       description: Not Found
+ *     500:
+ *       description: Server Error
+ */
+maintenanceRecordsRouter.get(
+  '/',
+  maintenanceRecordController.getMaintenanceRecords
+);
+
+/**
+ * @openapi
+ * '/api/maintenanceRecords/{maintenanceRecordId}':
+ *  get:
+ *    tags:
+ *    - MaintenanceRecord Controller
+ *    summary: Get a maintenanceRecord by id
+ *    parameters:
+ *     - id: maintenanceRecordId
+ *       in: path
+ *       description: The unique Id of the maintenanceRecord
+ *       required: true
+ *    responses:
+ *      200:
+ *        description: Fetched Successfully
+ *      400:
+ *        description: Bad Request
+ *      404:
+ *        description: Not Found
+ *      500:
+ *        description: Server Error
+ */
+maintenanceRecordsRouter.get(
+  '/:maintenanceRecordId',
+  authMiddleware.userExtractor,
+  validateMaintenanceRecordsId,
+  maintenanceRecordController.getMaintenanceRecordById
+);
+
+/**
+ * @openapi
+ * '/api/maintenanceRecord/{maintenanceRecordId}/user':
+ *  get:
+ *     tags:
+ *     - MaintenanceRecord Controller
+ *     summary: Get an maintenanceRecord and the user associated with it
+ *     parameters:
+ *      - id: maintenanceRecordId
+ *        in: path
+ *        description: The unique Id of the maintenanceRecord
+ *        required: true
+ *     responses:
+ *      200:
+ *        description: Fetched Successfully
+ *      400:
+ *        description: Bad Request
+ *      404:
+ *        description: Not Found
+ *      500:
+ *        description: Server Error
+ */
+maintenanceRecordsRouter.get(
+  '/:maintenanceRecordId/user',
+  validateMaintenanceRecordsId,
+  maintenanceRecordController.getMaintenanceRecordAndUser
+);
+
+/** PUT Methods */
+/**
+ * @openapi
+ * '/api/maintenanceRecords/{maintenanceRecordId}':
+ *  put:
+ *     tags:
+ *     - MaintenanceRecord Controller
+ *     summary: Modify a maintenanceRecord
+ *     requestBody:
+ *      required: true
+ *      content:
+ *        application/json:
+ *           schema:
+ *            type: object
+ *            required:
+ *              - maintenanceRecordId
+ *            properties:
+ *              description:
+ *                type: string
+ *                default: This is a description
+ *     responses:
+ *      200:
+ *        description: Modified
+ *      400:
+ *        description: Bad Request
+ *      404:
+ *        description: Not Found
+ *      500:
+ *        description: Server Error
+ */
+maintenanceRecordsRouter.put(
+  '/:maintenanceRecordId',
+  authMiddleware.userExtractor,
+  validateMaintenanceRecordsId,
+  validatePartialMaintenanceRecord,
+  maintenanceRecordController.updateMaintenanceRecord
+);
+
+/** DELETE Methods */
+/**
+ * @openapi
+ * '/api/maintenanceRecords/{maintenanceRecordId}':
+ *  delete:
+ *     tags:
+ *     - MaintenanceRecord Controller
+ *     summary: Delete maintenanceRecord by Id
+ *     parameters:
+ *      - name: maintenanceRecordId
+ *        in: path
+ *        description: The unique Id of the maintenanceRecord
+ *        required: true
+ *     responses:
+ *      200:
+ *        description: Removed
+ *      400:
+ *        description: Bad request
+ *      404:
+ *        description: Not Found
+ *      500:
+ *        description: Server Error
+ */
+maintenanceRecordsRouter.delete(
+  '/:maintenanceRecordId',
+  authMiddleware.userExtractor,
+  validateMaintenanceRecordsId,
+  maintenanceRecordController.deleteMaintenanceRecord
+);
+
+module.exports = maintenanceRecordsRouter;


### PR DESCRIPTION
## Pull Request

### Description
- Add create service request feature with the possibility to create a new maintenance record from an existing appointment or create the appointment record first before proceeeding to create the maintenance record 
- Add attachServices and attachInventory helper functions to update reference tables in many-to-many relationshop accordingly
- Add maintenance records model, controller and routes
- Add API documentation for route

## Issue ticket number and link

[AA-51](https://igit.atlassian.net/jira/software/projects/AA/boards/1?selectedIssue=AA-51)

### Changes Made
- Add model, controller and routes
- Add API docs
- Update user, appointments and maintenance records features to work accordingly
- Update models to return required fields
- Add migrations 

### Screenshots

### Checklist

- [x] Self-reviewed my code prior to submission.
- [ ] Tests have been added or updated (if applicable).
- [x] Documentation has been updated (if applicable).
- [x] This PR is ready for review.
- [ ] Screenshots added (if applicable).


[AA-51]: https://igit.atlassian.net/browse/AA-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ